### PR TITLE
Changes that allows dev mode overrides for network

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,13 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true,
     "es6": true
   },
+  "globals": {},
   "rules": {
     "no-extend-native": 2,
     "no-extra-parens": 0,
@@ -15,6 +18,10 @@
         "functions": false
       }
     ],
+    "prefer-const": ["error", {
+      "destructuring": "any",
+      "ignoreReadBeforeAssign": false
+    }],
     "max-statements": [
       2,
       20
@@ -65,8 +72,8 @@
     "one-var": [
       2,
       {
-        "uninitialized": "always",
-        "initialized": "never"
+        "initialized": "never",
+        "uninitialized": "always"
       }
     ],
     "newline-after-var": [
@@ -85,7 +92,6 @@
       2,
       {}
     ],
-    "func-names": [ "error", "never" ],
-    "brace-style": [ "error", "1tbs" ]
+    "func-names": 2
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-  0.10
-  0.11
-  0.12
-  4.0
-  4.1
+  4.9
+  6.14
+  8.11
 
 notifications:
   slack: lenddo:iJYeCC5sZSx2A0BW5dvgZiBe

--- a/README.md
+++ b/README.md
@@ -12,36 +12,48 @@ All of the following examples assume you you have used the setup defined immedia
 ```javascript
 // Configuration - Both of these can be found after logging into the Partners Dashboard.
 // If you have difficulty obtaining these please contact your Lenddo account manager.
-var id = '{YOUR_API_USER_ID}';
-var secret = '{YOUR_API_SECRET}';
+const api_id = '{YOUR_API_USER_ID}';
+const api_secret = '{YOUR_API_SECRET}';
 
 // Import clients
-var lenddo_clients = require('lenddo').clients;
+const lenddo_clients = require('lenddo').clients;
 ```
 
 ## Submitting Onboarding Priority Data
 ```javascript
 // this is the application_id (formerly client_id) that you sent us initially.
-var application_id = '{YOUR_APPLICATION_ID}';
-var application_id = '{THE_UNIQUE_APPLICATION_IDENTIFIER}';
-var partner_script_id = '{THE_PARTNER_SCRIPT_FOR_THE_APPLICATION_ID}';
-var priority_data = '{THE_PARTNER_DATA_AND_VERIFICATION_DATA_TO_USE}';
+const application_id = 'ADONISTEST' + Date.now();
+const partner_script_id = '000000000000000000000000';
+const priority_data = { //The verification and partner data overwrites
+	verification_data: {
+		name: {
+			first: 'Adonis',
+			middle: 'Lee',
+			last: 'Villamor'
+		},
+
+	},
+	partner_data: {
+		some: 'data',
+		another: 'data'
+	}
+};
 
 // begin main script
-var AuthorizeService = lenddo_clients.Authorize;
-var authorize_client = new AuthorizeService(application_id, client_secret);
+const AuthorizeService = lenddo_clients.Authorize;
+const authorize_client = new AuthorizeService(api_id, api_secret);
 
 ```
 ### PriorityData
 ```javascript
 authorize_client.PriorityData.post(application_id, partner_script_id, priority_data)
-    .exec(function(err, result) {
+    .exec((err, result) => {
     	if (err) { //there should be no error
     		throw err;
     	} else if (result.response.code !== 200) {
     		throw new Error(result.response.raw); //throw the failed response from AUTHORIZE
     	}
-      var response = result.response;
+      const response = result.response;
       /**
       * the submission should be a success from here
       **/
@@ -52,18 +64,18 @@ authorize_client.PriorityData.post(application_id, partner_script_id, priority_d
 ## Score Service (Get User Score, Verification, etc.)
 ```javascript
 // this is the client ID that you sent us initially.
-var application_id = '{YOUR_APPLICATION_ID}';
-var partner_script_id = '{THE_PARTNER_SCRIPT_IDENTIFIER}';
+const application_id = '{YOUR_APPLICATION_ID}';
+const partner_script_id = '{THE_PARTNER_SCRIPT_IDENTIFIER}';
 
 // begin main script
-var ScoreService = lenddo_clients.Score;
-var client_instance = new ScoreService(id, secret);
+const ScoreService = lenddo_clients.Score;
+const client_instance = new ScoreService(api_id, api_secret);
 ```
 ### Application Score Card
 ```javascript
 client_instance.ApplicationScoreCard.get(application_id, partner_script_id)
     .exec(function(err, result) {
-      var response = result.response;
+      const response = result.response;
       console.log(response.data);
     });
 ```
@@ -71,7 +83,7 @@ client_instance.ApplicationScoreCard.get(application_id, partner_script_id)
 ```javascript
 client_instance.ApplicationFeatures.get(application_id, partner_script_id)
     .exec(function(err, result) {
-      var response = result.response;
+      const response = result.response;
       console.log(response.data);
     });
 ```
@@ -79,7 +91,7 @@ client_instance.ApplicationFeatures.get(application_id, partner_script_id)
 ```javascript
 client_instance.ApplicationMultipleScores.get(application_id, partner_script_id)
     .exec(function(err, result) {
-      var response = result.response;
+      const response = result.response;
       console.log(response.data);
     });
 ```
@@ -87,7 +99,7 @@ client_instance.ApplicationMultipleScores.get(application_id, partner_script_id)
 ```javascript
 client_instance.ClientScore.get(application_id, partner_script_id)
     .exec(function(err, result) {
-      var response = result.response;
+      const response = result.response;
       /**
       * response.data should look like the following:
       * { score: 521, flags: [] }
@@ -99,7 +111,7 @@ client_instance.ClientScore.get(application_id, partner_script_id)
 ```javascript
 client_instance.ClientVerification.get(application_id, partner_script_id)
     .exec(function(err, result) {
-      var response = result.response;
+      const response = result.response;
       /**
       * response.data should contain a large object detailing the verification results.
       **/
@@ -111,10 +123,10 @@ client_instance.ClientVerification.get(application_id, partner_script_id)
 If you have an implementation with our android SDK and want access to the mobile data stream please use the following API call:
 ```javascript
 // this is the partner script ID you used in the data SDK
-var partner_script_id = '{YOUR_PARTNER_SCRIPT_ID}';
+const partner_script_id = '{YOUR_PARTNER_SCRIPT_ID}';
 
-var NetworkService = lenddo_clients.Network;
-var client_instance = new NetworkService(id, secret);
+const NetworkService = lenddo_clients.Network;
+const client_instance = new NetworkService(api_id, api_secret);
 
 client_instance.MobileData.get(partner_script_id).exec(function(err, response) {
     /**
@@ -133,8 +145,8 @@ To use the whitelabel functionality you **must** use both of the following comma
 All of the Whitelabel functionality relies on the `Network Service`. You'll need to instantiate the Network Service Client in the following manner:
 
 ```javascript
-var NetworkService = require('lenddo').clients.Network;
-var client_instance = new NetworkService(id, secret);
+const NetworkService = require('lenddo').clients.Network;
+const client_instance = new NetworkService(api_id, api_secret);
 ```
 
 The remainder of the _WhiteLabel_ functionality documentation section will assume you're using `client_instance` as the variable name for your Network Service client, as the above example shows.
@@ -158,7 +170,7 @@ At this stage you must have:
 
 #### Sample Token Submission Code
 ```javascript
-var profile_ids = [];
+const profile_ids = [];
 
 client_instance.ClientToken.post(application_id, partner_script_id, provider, token).exec(function (err, data) {
 	if (err) {
@@ -192,10 +204,10 @@ This step is optional and not necessary if you are not using Lenddo's Verificati
 
 ##### Verification Sample Code 
 ```javascript
-var VerificationObject = require('lenddo').verification;
+const VerificationObject = require('lenddo').verification;
 
 // Get an instance of the verification object
-var user_verification = new VerificationObject();
+const user_verification = new VerificationObject();
 // Define probes to be verified (Everything is optional)
 user_verification.set.firstName('John')
                 .middleName('J')

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ var lenddo_clients = require('lenddo').clients;
 
 ## Submitting Onboarding Priority Data
 ```javascript
-// this is the client ID that you sent us initially.
-var client_id = '{YOUR_CLIENT_ID}';
+// this is the application_id (formerly client_id) that you sent us initially.
+var application_id = '{YOUR_APPLICATION_ID}';
 var application_id = '{THE_UNIQUE_APPLICATION_IDENTIFIER}';
 var partner_script_id = '{THE_PARTNER_SCRIPT_FOR_THE_APPLICATION_ID}';
 var priority_data = '{THE_PARTNER_DATA_AND_VERIFICATION_DATA_TO_USE}';
 
 // begin main script
 var AuthorizeService = lenddo_clients.Authorize;
-var authorize_client = new AuthorizeService(client_id, client_secret);
+var authorize_client = new AuthorizeService(application_id, client_secret);
 
 ```
 ### PriorityData
@@ -49,19 +49,43 @@ authorize_client.PriorityData.post(application_id, partner_script_id, priority_d
     });
 ```
 
-## Get User Score and Verification
+## Score Service (Get User Score, Verification, etc.)
 ```javascript
 // this is the client ID that you sent us initially.
-var client_id = '{YOUR_CLIENT_ID}';
-var partner_script_id = '{THE_PARTNER_SCRIPT_FOR_YOUR_CLIENT_ID}';
+var application_id = '{YOUR_APPLICATION_ID}';
+var partner_script_id = '{THE_PARTNER_SCRIPT_IDENTIFIER}';
 
 // begin main script
 var ScoreService = lenddo_clients.Score;
 var client_instance = new ScoreService(id, secret);
 ```
+### Application Score Card
+```javascript
+client_instance.ApplicationScoreCard.get(application_id, partner_script_id)
+    .exec(function(err, result) {
+      var response = result.response;
+      console.log(response.data);
+    });
+```
+### Application Features
+```javascript
+client_instance.ApplicationFeatures.get(application_id, partner_script_id)
+    .exec(function(err, result) {
+      var response = result.response;
+      console.log(response.data);
+    });
+```
+### Application Multiple Scores
+```javascript
+client_instance.ApplicationMultipleScores.get(application_id, partner_script_id)
+    .exec(function(err, result) {
+      var response = result.response;
+      console.log(response.data);
+    });
+```
 ### Score
 ```javascript
-client_instance.ClientScore.get(client_id, partner_script_id)
+client_instance.ClientScore.get(application_id, partner_script_id)
     .exec(function(err, result) {
       var response = result.response;
       /**
@@ -73,7 +97,7 @@ client_instance.ClientScore.get(client_id, partner_script_id)
 ```
 ### Verification
 ```javascript
-client_instance.ClientVerification.get(client_id, partner_script_id)
+client_instance.ClientVerification.get(application_id, partner_script_id)
     .exec(function(err, result) {
       var response = result.response;
       /**

--- a/lib/clients/authorize/index.js
+++ b/lib/clients/authorize/index.js
@@ -5,7 +5,8 @@ const util = require('util');
 
 function AuthorizeService() {
 	const self = this instanceof AuthorizeService ? this : new AuthorizeService();
-	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_AUTHORIZE_API_URL?
+	const host = [ 'development', 'qa' ].indexOf(process.env.NODE_ENV) !== -1
+		&& process.env.DEV_MODE_AUTHORIZE_API_URL?
 		process.env.DEV_MODE_AUTHORIZE_API_URL : 'https://authorize-api.partner-service.link';
 
 	self._defaults = { host };

--- a/lib/clients/authorize/index.js
+++ b/lib/clients/authorize/index.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var client = require('../_base').Client;
-var util = require('util');
+const client = require('../_base').Client;
+const util = require('util');
 
 function AuthorizeService() {
-	var self = this instanceof AuthorizeService ? this : new AuthorizeService();
+	const self = this instanceof AuthorizeService ? this : new AuthorizeService();
+	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_AUTHORIZE_API_URL?
+		process.env.DEV_MODE_AUTHORIZE_API_URL : 'https://authorize-api.partner-service.link';
 
-	self._defaults = {
-		host: 'https://authorize-api.partner-service.link'
-	};
+	self._defaults = { host };
 
 	self.PriorityData = {
 		post: function(application_id, partner_script_id, priority_data) {

--- a/lib/clients/authorize/index.js
+++ b/lib/clients/authorize/index.js
@@ -7,7 +7,7 @@ function AuthorizeService() {
 	var self = this instanceof AuthorizeService ? this : new AuthorizeService();
 
 	self._defaults = {
-		host: 'https://authorize-api.lenddo.com'
+		host: 'https://authorize-api.partner-service.link'
 	};
 
 	self.PriorityData = {

--- a/lib/clients/network/index.js
+++ b/lib/clients/network/index.js
@@ -11,7 +11,8 @@ const valid_networks = [ 'Facebook', 'LinkedIn', 'Yahoo', 'WindowsLive', 'Google
 // begin module
 function NetworkService() {
 	const self = this instanceof NetworkService ? this : new NetworkService();
-	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_NETWORK_SERVICE_URL?
+	const host = [ 'development', 'qa' ].indexOf(process.env.NODE_ENV) !== -1
+		&& process.env.DEV_MODE_NETWORK_SERVICE_URL ?
 		process.env.DEV_MODE_NETWORK_SERVICE_URL : 'https://networkservice.lenddo.com';
 
 	self._defaults = { host };

--- a/lib/clients/network/index.js
+++ b/lib/clients/network/index.js
@@ -1,20 +1,20 @@
 "use strict";
 
 // imports
-var client = require('../_base').Client;
-var util = require('util');
-var Verification = require('../../Verification');
+const client = require('../_base').Client;
+const util = require('util');
+const Verification = require('../../Verification');
 
 // module config
-var valid_networks = [ 'Facebook', 'LinkedIn', 'Yahoo', 'WindowsLive', 'Google' ];
+const valid_networks = [ 'Facebook', 'LinkedIn', 'Yahoo', 'WindowsLive', 'Google' ];
 
 // begin module
 function NetworkService() {
-	var self = this instanceof NetworkService ? this : new NetworkService();
+	const self = this instanceof NetworkService ? this : new NetworkService();
+	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_NETWORK_SERVICE_URL?
+		process.env.DEV_MODE_NETWORK_SERVICE_URL : 'https://networkservice.lenddo.com';
 
-	self._defaults = {
-		host: 'https://networkservice.lenddo.com'
-	};
+	self._defaults = { host };
 
 	self.MobileData = {
 		get: function(partner_script_id) {

--- a/lib/clients/score/index.js
+++ b/lib/clients/score/index.js
@@ -34,6 +34,30 @@ function ScoreService() {
 		}
 	};
 
+	self.ApplicationScoreCard = {
+		get: function (application_id, partner_script_id) {
+			return self.get('ApplicationScorecards/' + application_id).query({
+				partner_script_id: partner_script_id
+			});
+		}
+	};
+
+	self.ApplicationFeatures = {
+		get: function (application_id, partner_script_id) {
+			return self.get('ApplicationFeatures/' + application_id).query({
+				partner_script_id: partner_script_id
+			});
+		}
+	};
+
+	self.ApplicationMultipleScores = {
+		get: function (application_id, partner_script_id) {
+			return self.get('ApplicationMultipleScores/' + application_id).query({
+				partner_script_id: partner_script_id
+			});
+		}
+	};
+
 	// Apply arguments as config if available.
 	if (arguments.length >= 2) {
 		self.config.apply(self, arguments);

--- a/lib/clients/score/index.js
+++ b/lib/clients/score/index.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var client = require('../_base').Client;
-var util = require('util');
+const client = require('../_base').Client;
+const util = require('util');
 
 function ScoreService() {
-	var self = this instanceof ScoreService ? this : new ScoreService();
+	const self = this instanceof ScoreService ? this : new ScoreService();
+	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_SCORE_SERVICE_URL?
+		process.env.DEV_MODE_SCORE_SERVICE_URL : 'https://scoreservice.lenddo.com';
 
-	self._defaults = {
-		host: 'https://scoreservice.lenddo.com'
-	};
+	self._defaults = { host };
 
 	self.ClientRecommendation = {
 		get: function (application_id, partner_script_id) {

--- a/lib/clients/score/index.js
+++ b/lib/clients/score/index.js
@@ -5,7 +5,8 @@ const util = require('util');
 
 function ScoreService() {
 	const self = this instanceof ScoreService ? this : new ScoreService();
-	const host = process.env.NODE_ENV === 'development' && process.env.DEV_MODE_SCORE_SERVICE_URL?
+	const host = [ 'development', 'qa' ].indexOf(process.env.NODE_ENV) !== -1
+		&& process.env.DEV_MODE_SCORE_SERVICE_URL?
 		process.env.DEV_MODE_SCORE_SERVICE_URL : 'https://scoreservice.lenddo.com';
 
 	self._defaults = { host };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,680 @@
+{
+  "name": "lenddo",
+  "version": "1.10.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "should": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
+      "integrity": "sha1-ZGTEi298Hh8YrASDV4+i3VXCxuA=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.5.0",
+        "should-format": "0.3.1",
+        "should-type": "0.2.0"
+      }
+    },
+    "should-equal": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
+      "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-format": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.1.tgz",
+      "integrity": "sha1-LLt4JGFnCs5CkrKx7EaNuM+Z4zA=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
+    },
+    "should-type": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.2.0.tgz",
+      "integrity": "sha1-ZwfvlVKdmJ3MCY/gdTqx+RNrt/Y=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenddo",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "client base for lenddo services",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lenddo",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "client base for lenddo services",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
These changes allow us to test the SDK  by rerouring the default production URLS to our dev services. Travis ci was updated to use the top 3 latest NODE JS LTS versions. and readme erratas are made that confuses users.